### PR TITLE
further modification required for successful compilation & test execution

### DIFF
--- a/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcSDERasterGeoResource.java
+++ b/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcSDERasterGeoResource.java
@@ -21,7 +21,7 @@ import org.locationtech.udig.catalog.IGeoResourceInfo;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.geotools.arcsde.ArcSDERasterFormatFactory;
+import org.geotools.arcsde.data.ArcSDERasterFormatFactory;
 import org.geotools.arcsde.raster.gce.ArcSDERasterFormat;
 import org.geotools.arcsde.session.ArcSDEConnectionConfig;
 import org.geotools.coverage.grid.io.AbstractGridCoverage2DReader;
@@ -63,7 +63,7 @@ public class ArcSDERasterGeoResource extends IGeoResource {
             GeneralEnvelope env = reader.getOriginalEnvelope();
             Envelope bounds = new Envelope(env.getMinimum(0), env.getMaximum(0), env.getMinimum(1),
                     env.getMaximum(1));
-            CoordinateReferenceSystem crs = reader.getCrs();
+            CoordinateReferenceSystem crs = reader.getCoordinateReferenceSystem();
             ImageDescriptor icon = null;
             IGeoResourceInfo rasterInfo = new IGeoResourceInfo(title, name, description, schema,
                     bounds, crs, keywords, icon);

--- a/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcSDEVectorService.java
+++ b/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcSDEVectorService.java
@@ -18,7 +18,7 @@ import org.locationtech.udig.catalog.IGeoResource;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.geotools.arcsde.ArcSDEDataStoreFactory;
+import org.geotools.arcsde.data.ArcSDEDataStoreFactory;
 import org.geotools.arcsde.data.ArcSDEDataStore;
 import org.geotools.arcsde.data.ArcSDEDataStoreConfig;
 import org.geotools.arcsde.session.ISessionPool;

--- a/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcServiceExtension.java
+++ b/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ArcServiceExtension.java
@@ -11,12 +11,12 @@
  */
 package org.locationtech.udig.catalog.internal.arcsde;
 
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.DBTYPE_PARAM;
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.INSTANCE_PARAM;
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.PASSWORD_PARAM;
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.PORT_PARAM;
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.SERVER_PARAM;
-import static org.geotools.arcsde.ArcSDEDataStoreFactory.USER_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.DBTYPE_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.INSTANCE_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.PASSWORD_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.PORT_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.SERVER_PARAM;
+import static org.geotools.arcsde.data.ArcSDEDataStoreFactory.USER_PARAM;
 
 import java.io.Serializable;
 import java.net.MalformedURLException;
@@ -29,7 +29,7 @@ import org.locationtech.udig.catalog.IService;
 import org.locationtech.udig.catalog.ServiceExtension;
 import org.locationtech.udig.catalog.arcsde.internal.Messages;
 
-import org.geotools.arcsde.ArcSDEDataStoreFactory;
+import org.geotools.arcsde.data.ArcSDEDataStoreFactory;
 import org.geotools.data.DataStoreFactorySpi;
 
 /**

--- a/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ui/ArcSDEPreferences.java
+++ b/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ui/ArcSDEPreferences.java
@@ -17,7 +17,7 @@ import org.locationtech.udig.catalog.ui.preferences.AbstractProprietaryJarPrefer
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.geotools.arcsde.ArcSDEDataStoreFactory;
+import org.geotools.arcsde.data.ArcSDEDataStoreFactory;
 
 /**
  * @author Jesse

--- a/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ui/ArcSDEWizardPage.java
+++ b/plugins/org.locationtech.udig.catalog.arcsde/src/org/locationtech/udig/catalog/internal/arcsde/ui/ArcSDEWizardPage.java
@@ -25,7 +25,7 @@ import org.locationtech.udig.catalog.ui.preferences.AbstractProprietaryJarPrefer
 import org.locationtech.udig.catalog.ui.wizard.DataBaseConnInfo;
 
 import org.eclipse.swt.widgets.Composite;
-import org.geotools.arcsde.ArcSDEDataStoreFactory;
+import org.geotools.arcsde.data.ArcSDEDataStoreFactory;
 import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.data.DataStoreFactorySpi;
 

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/util/GeoToolsAdaptersTest.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/tests/util/GeoToolsAdaptersTest.java
@@ -14,6 +14,7 @@ import org.locationtech.udig.catalog.util.GeoToolsAdapters;
 import org.locationtech.udig.ui.ProgressMonitorTaskNamer;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.geotools.util.NameFactory;
 import org.opengis.util.ProgressListener;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -62,7 +63,7 @@ public class GeoToolsAdaptersTest {
         Monitor monitor = new Monitor();
         
         ProgressListener progress = GeoToolsAdapters.progress(monitor);
-//        progress.setDescription("go");
+        progress.setTask(NameFactory.create("go").toInternationalString());
         progress.started();
         
         assertEquals("test started", 0.0, monitor.work, 0.01 );

--- a/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/util/GeoToolsAdapters.java
+++ b/plugins/org.locationtech.udig.catalog/src/org/locationtech/udig/catalog/util/GeoToolsAdapters.java
@@ -92,7 +92,6 @@ public class GeoToolsAdapters {
 	static public ProgressListener progress(final IProgressMonitor monitor) {
 		if( monitor == null ) return null;
 		return new ProgressListener(){
-			private String description;
 			private int progress;
 			private InternationalString task;
 			
@@ -100,12 +99,9 @@ public class GeoToolsAdapters {
 				monitor.done();
 			}
 			public void dispose() {
-				description = null;
+				task = null;
 			}
 			public void exceptionOccurred(Throwable arg0) {				
-			}
-			public String getDescription() {
-				return description;
 			}
 			public boolean isCanceled() {
 				return monitor.isCanceled();
@@ -120,12 +116,8 @@ public class GeoToolsAdapters {
 				monitor.setCanceled(true);
 			}
 
-			public void setDescription(String text) {
-				description = text;
-			}
-
 			public void started() {
-				monitor.beginTask( description, 100);
+				monitor.beginTask( task != null ? task.toString() : null, 100);
 			}
 
 			public void warningOccurred(String arg0, String arg1, String arg2) {				

--- a/plugins/org.locationtech.udig.libs.tests/src/org/locationtech/udig/libs/tests/GeoToolsTest.java
+++ b/plugins/org.locationtech.udig.libs.tests/src/org/locationtech/udig/libs/tests/GeoToolsTest.java
@@ -56,8 +56,8 @@ public class GeoToolsTest {
     @Test
     public void testGeoTools(){
         Version version = GeoTools.getVersion();
-        assertEquals( 19, version.getMajor() );
-        assertEquals( 4, version.getMinor() );
+        assertEquals( 22, version.getMajor() );
+        assertEquals( 0, version.getMinor() );
     }
 
     @Ignore("FIXME: due to migration to batik bundle from Orbit")

--- a/plugins/org.locationtech.udig.project.ui.tests/plugin.xml
+++ b/plugins/org.locationtech.udig.project.ui.tests/plugin.xml
@@ -70,7 +70,7 @@
              name="MatchAnyGeom">
           <featureType>
              <attribute
-                   type="com.vividsolutions.jts.geom.Geometry"/>
+                   type="org.locationtech.jts.geom.Geometry"/>
           </featureType>
        </editor>
 	      <editor
@@ -85,7 +85,7 @@
           <featureType>
              <attribute
                    name="geo"
-                   type="com.vividsolutions.jts.geom.Geometry"/>
+                   type="org.locationtech.jts.geom.Geometry"/>
           </featureType>
        </editor>
             point="org.locationtech.udig.project.ui.featureEditor">

--- a/plugins/org.locationtech.udig.project.ui/plugin.xml
+++ b/plugins/org.locationtech.udig.project.ui/plugin.xml
@@ -298,7 +298,7 @@
      </factory>
      <factory
            class="org.locationtech.udig.project.ui.internal.adapters.FeatureAdapterFactory"
-           adaptableType="com.vividsolutions.jts.geom.Geometry">
+           adaptableType="org.locationtech.jts.geom.Geometry">
         <adapter type="org.eclipse.ui.views.properties.IPropertySource"/>
         <adapter type="org.eclipse.ui.views.properties.IPropertySource2"/>
         <adapter type="org.eclipse.jface.viewers.ITreeContentProvider"/>
@@ -311,7 +311,7 @@
 	</factory>
      <factory
            class="org.locationtech.udig.project.ui.internal.adapters.FeatureAdapterFactory"
-           adaptableType="com.vividsolutions.jts.geom.Coordinate">
+           adaptableType="org.locationtech.jts.geom.Coordinate">
         <adapter type="org.eclipse.ui.views.properties.IPropertySource"/>
         <adapter type="org.eclipse.ui.views.properties.IPropertySource2"/>
         <adapter type="org.eclipse.jface.viewers.ITreeContentProvider"/>
@@ -324,7 +324,7 @@
      </factory>
      <factory
            class="org.locationtech.udig.project.ui.internal.adapters.FeatureAdapterFactory"
-           adaptableType="com.vividsolutions.jts.geom.Coordinate">
+           adaptableType="org.locationtech.jts.geom.Coordinate">
         <adapter type="org.eclipse.jface.viewers.ITreeContentProvider"/>
         <adapter type="org.eclipse.jface.viewers.IStructuredContentProvider"/>
         <adapter type="org.eclipse.jface.viewers.IContentProvider"/>

--- a/plugins/org.locationtech.udig.tool.edit/plugin.xml
+++ b/plugins/org.locationtech.udig.tool.edit/plugin.xml
@@ -26,9 +26,9 @@
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
 	                        <property
-                               expectedValue="com.vividsolutions.jts.geom.MultiPolygon"
+                               expectedValue="org.locationtech.jts.geom.MultiPolygon"
                                propertyId="GeometryType"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -56,8 +56,8 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -85,10 +85,10 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -113,8 +113,8 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Point"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -138,12 +138,12 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Point"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -167,11 +167,11 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -195,11 +195,11 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -223,8 +223,8 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -252,8 +252,8 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -281,10 +281,10 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
 					</and>
                   </enablement>
@@ -312,10 +312,10 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
 	                     </or>
                      </and>
                   </enablement>
@@ -344,12 +344,12 @@
                         <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                         <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Point"/>
 	                     </or>
                      </and>
                   </enablement>

--- a/plugins/org.locationtech.udig.tool.select/plugin.xml
+++ b/plugins/org.locationtech.udig.tool.select/plugin.xml
@@ -47,12 +47,12 @@
                   	<and>
                         <property propertyId="FeatureSourceResourceProperty" expectedValue=""/>                  	
 	                     <or>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                        <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
+	                        <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Point"/>
 	                     </or>
                       <property
                             expectedValue="SELECT"

--- a/plugins/org.locationtech.udig.tools.jgrass/plugin.xml
+++ b/plugins/org.locationtech.udig.tools.jgrass/plugin.xml
@@ -86,8 +86,8 @@
              <and>
                <property propertyId="org.locationtech.udig.project.FeatureStoreResourceProperty" expectedValue=""/>  
                <or>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
                </or>
              </and>
             </enablement>
@@ -104,10 +104,10 @@
              <and>
                <property propertyId="org.locationtech.udig.project.FeatureStoreResourceProperty" expectedValue=""/>  
                <or>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
                </or>
              </and>
             </enablement>

--- a/plugins/org.locationtech.udig.tools/plugin.xml
+++ b/plugins/org.locationtech.udig.tools/plugin.xml
@@ -22,10 +22,10 @@
                 <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                 <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
                  <or>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
                  </or>
              </and>
           </enablement>
@@ -45,12 +45,12 @@
 	            <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
 	            <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
 	             <or>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPolygon"/>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Polygon"/>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiPoint"/>
-	                <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.Point"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPolygon"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Polygon"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiPoint"/>
+	                <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.Point"/>
 	             </or>
 	         </and>
 	      </enablement>
@@ -67,11 +67,11 @@
          <enablement>
             <or>
                <property
-                     expectedValue="com.vividsolutions.jts.geom.LineString"
+                     expectedValue="org.locationtech.jts.geom.LineString"
                      propertyId="GeometryType">
                </property>
                <property
-                     expectedValue="com.vividsolutions.jts.geom.MultiLineString"
+                     expectedValue="org.locationtech.jts.geom.MultiLineString"
                      propertyId="GeometryType">
                </property>
             </or>
@@ -95,8 +95,8 @@
                 <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                 <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
                  <or>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
                  </or>
              </and>
          </enablement>
@@ -116,8 +116,8 @@
                 <property propertyId="FeatureStoreResourceProperty" expectedValue=""/>
                 <property propertyId="InteractionProperty" expectedValue="interaction_edit"/>
                  <or>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.MultiLineString"/>
-                    <property propertyId="GeometryType" expectedValue="com.vividsolutions.jts.geom.LineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.MultiLineString"/>
+                    <property propertyId="GeometryType" expectedValue="org.locationtech.jts.geom.LineString"/>
                  </or>
              </and>
          </enablement>

--- a/plugins/org.locationtech.udig.tutorials.featureeditor/plugin.xml
+++ b/plugins/org.locationtech.udig.tutorials.featureeditor/plugin.xml
@@ -19,7 +19,7 @@
             viewId="org.locationtech.udig.tutorials.featureeditor.views.country">
          <featureType>
             <attribute
-                  type="com.vividsolutions.jts.geom.MultiPolygon">
+                  type="org.locationtech.jts.geom.MultiPolygon">
             </attribute>
             <attribute
                   name="CNTRY_NAME"
@@ -48,7 +48,7 @@
             title="Country Feature">
          <featureType>
             <attribute
-                  type="com.vividsolutions.jts.geom.MultiPolygon">
+                  type="org.locationtech.jts.geom.MultiPolygon">
             </attribute>
             <attribute
                   name="CNTRY_NAME"
@@ -71,7 +71,7 @@
             title="Statistics">
          <featureType>
             <attribute
-                  type="com.vividsolutions.jts.geom.MultiPolygon">
+                  type="org.locationtech.jts.geom.MultiPolygon">
             </attribute>
             <attribute
                   name="CNTRY_NAME"

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <java-version>1.7</java-version>
+        <java-version>1.8</java-version>
         <tycho-version>1.4.0</tycho-version>
         <tycho-extras-version>1.4.0</tycho-extras-version>
         <!-- necessary for e.g. hudson proxy settings


### PR DESCRIPTION
changes include:

- replacement of 'com.vividsolutions.jts.geom' --> 'org.locationtech.jts.geom' in plugin.xml files
- replacement of 'org.geotools.arcsde.' --> 'org.geotools.arcsde.data.'  in  org.locationtech.udig.catalog.arcsde
- fix of GeoToolsAdaptersTest test
- fix of GeoToolsTest.java  (version test)
- change java-version property to 1.8 (required since the code contains now lamda expressions)

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>